### PR TITLE
Add Section 5: deprecated field handling audit to settings validation matrix

### DIFF
--- a/standards/audits/settings-validation-matrix.md
+++ b/standards/audits/settings-validation-matrix.md
@@ -249,89 +249,150 @@ These module config screens are present in Android but have no equivalent in the
 
 ## 5. Deprecated Field Handling
 
-This section audits all fields and enum values marked `[deprecated = true]` in the Meshtastic protobufs and compares how Android and Apple handle them in their UIs. Fields may be deprecated because: they were moved to a different message, replaced by a successor field, or removed from active firmware support.
+This section audits all fields and enum values marked `[deprecated = true]` in the Meshtastic protobufs and compares how Android and Apple handle them in their UIs.
 
 ### Methodology
 
-Proto files were inspected for the `[deprecated = true]` annotation. The `.options` files were also cross-referenced. For each deprecated item the UI source code of both apps was read to determine whether the item is: **hidden** (not shown to users), **shown but read-only / informational**, **still writable** (the deprecated field is actively surfaced and written), or **actively migrated** (the app converts the old value to the replacement on load).
+Proto files (`config.proto`, `module_config.proto`, `mesh.proto`) and their `.options` files were inspected for `[deprecated = true]`. The git log of the protobufs repo was used to identify the commit that added each annotation, and firmware release dates were cross-referenced to identify the first firmware version that shipped the change. The actual UI source code of both apps was then read to determine handling.
+
+**Version column key:** *Announced* = first firmware release (pre or stable) that included the deprecation commit. *Stable* = first stable release.
 
 ---
 
 ### 5.1 Deprecated Enum Values
 
-These proto enum values are annotated `[deprecated = true]` and should not be offered in new configurations.
-
-| Enum | Value | Deprecated since | Reason | Android | Apple |
-|------|-------|-----------------|--------|---------|-------|
-| `DeviceConfig.Role` | `ROUTER_CLIENT = 3` | v2.3.15 | Improper usage impacting public meshes; use ROUTER or CLIENT instead | ✅ **Filtered out** — `DropDownPreference` uses JVM reflection (`isDeprecatedEnumEntry()`) to remove all deprecated enum constants from the picker at runtime. `@Suppress("DEPRECATION")` allows the existing value to be read and displayed if a device already has this role. | ✅ **Absent from enum + actively migrated** — `DeviceRoles` Swift enum has no `routerClient` case. On view load, `setDeviceValues()` silently rewrites role 3 → 1 (`CLIENT_MUTE`): `if node?.deviceConfig?.role ?? 0 == 3 { node?.deviceConfig?.role = 1 }` |
-| `DeviceConfig.Role` | `REPEATER = 4` | v2.7.11 | Creates "holes" in the mesh rebroadcast chain | ✅ **Filtered out** via `isDeprecatedEnumEntry()` reflection. Still readable/displayable if device has it. Included in `infrastructureRoles` list so it triggers the router role confirmation dialog. | ⚠️ **Absent from enum but no migration** — `DeviceRoles` has no `repeater` case. A device configured as REPEATER will have `deviceRole = 4`, which won't match any `DeviceRoles` case; `DeviceRoles(rawValue: 4)` returns `nil`. No explicit migration to a replacement role. |
-| `LoRaConfig.ModemPreset` | `LONG_SLOW = 1` | v2.7 | Unpopular slow preset | ✅ **Filtered out** via `isDeprecatedEnumEntry()` reflection. | ❌ **Still offered** — `ModemPresets` Swift enum includes `case longSlow = 1` and it is not excluded from `userSelectable`. Users can still select LONG_SLOW from the modem preset picker. |
-| `LoRaConfig.ModemPreset` | `VERY_LONG_SLOW = 2` | v2.5 | Works only with TCXO and unusably slow | ✅ **Filtered out** via `isDeprecatedEnumEntry()` reflection. | ✅ **Absent from enum** — `ModemPresets` has no `veryLongSlow` case. A device with this preset will have an unrecognised raw value in the picker. No migration logic. |
+| Enum | Value | Announced | Stable | Reason | Android | Apple |
+|------|-------|-----------|--------|--------|---------|-------|
+| `DeviceConfig.Role` | `ROUTER_CLIENT = 3` | v2.3.14 | **v2.3.15** (2024-07-08) | Improper usage impacting public meshes; use ROUTER or CLIENT | ✅ **Filtered** — `DropDownPreference` uses JVM reflection (`isDeprecatedEnumEntry()`) to remove all `@Deprecated`-annotated enum constants at runtime. `@Suppress("DEPRECATION")` lets the screen read the value if the device already has this role. | ✅ **Absent + actively migrated** — `DeviceRoles` Swift enum has no `routerClient` case. `setDeviceValues()` rewrites role 3 → 1 (`CLIENT_MUTE`): `if role == 3 { role = 1 }`. |
+| `DeviceConfig.Role` | `REPEATER = 4` | **v2.7.11** (2025-10-01) | v2.7.15 (2025-11-19) | Creates "holes" in the mesh rebroadcast chain | ✅ **Filtered** via `isDeprecatedEnumEntry()`. Included in the `infrastructureRoles` guard so it triggers the router confirmation dialog when already set. | ⚠️ **Absent but no migration** — `DeviceRoles` has no `repeater` case. A device configured as REPEATER has `deviceRole = 4`; `DeviceRoles(rawValue: 4)` returns `nil`. No migration to a replacement role. |
+| `LoRaConfig.ModemPreset` | `LONG_SLOW = 1` | v2.7.17 (2025-12-20 pre) | *(no stable yet — deprecated after v2.7.15)* | Unpopular slow preset, removed from active firmware support | ✅ **Filtered** via `isDeprecatedEnumEntry()` reflection. | ❌ **Still offered** — `ModemPresets` includes `case longSlow = 1` and it is not excluded from `userSelectable`. Users running any firmware can still select LONG_SLOW. |
+| `LoRaConfig.ModemPreset` | `VERY_LONG_SLOW = 2` | v2.7.4 (2025-08-09 pre); proto comment: "Deprecated in 2.5" | v2.7.15 (2025-11-19) | Works only with TCXO; unusably slow | ✅ **Filtered** via `isDeprecatedEnumEntry()`. | ✅ **Absent** — `ModemPresets` has no `veryLongSlow` case. No migration; a device with this preset will show an unrecognised value. |
 
 ---
 
 ### 5.2 Deprecated Fields — Moved to Another Message
 
-These fields were physically relocated to a different proto message. They remain in the original message for backward compatibility but should no longer be written.
-
-| Proto message | Field | Moved to | Android | Apple |
-|--------------|-------|----------|---------|-------|
-| `DeviceConfig` | `serial_enabled = 2` | `SecurityConfig.serial_enabled` | ✅ **Not shown** — DeviceConfigScreen has no reference to `serial_enabled`. The current value lives in SecurityConfig. | ✅ **Not shown** — DeviceConfig.swift has no reference. |
-| `DeviceConfig` | `is_managed = 9` | `SecurityConfig.is_managed` | ✅ **Not shown** in DeviceConfigScreen. Correctly surfaced only via SecurityConfigScreen. | ✅ **Not shown** in DeviceConfig.swift. Correctly surfaced only via SecurityConfig.swift. |
+| Proto message | Field | Moved in | Stable | Moved to | Android | Apple |
+|--------------|-------|----------|--------|----------|---------|-------|
+| `DeviceConfig` | `serial_enabled = 2` | v2.4.3 (2024-08-15 pre); `[deprecated=true]` annotated v2.7.4 | v2.5.11 | `SecurityConfig.serial_enabled` | ✅ **Not shown** in DeviceConfigScreen. Surfaced via SecurityConfigScreen. | ✅ **Not shown** in DeviceConfig.swift. |
+| `DeviceConfig` | `is_managed = 9` | v2.4.3 (2024-08-15 pre); `[deprecated=true]` annotated v2.7.4 | v2.5.11 | `SecurityConfig.is_managed` | ✅ **Not shown** in DeviceConfigScreen. | ✅ **Not shown** in DeviceConfig.swift. |
 
 ---
 
 ### 5.3 Deprecated Fields — Replaced by a Successor Field
 
-These fields were superseded by a newer field in the same message. The deprecated field should not be written and ideally should not be shown.
-
-| Proto message | Deprecated field | Successor field | Android | Apple |
-|--------------|-----------------|----------------|---------|-------|
-| `PositionConfig` | `gps_enabled = 4` — *"Is GPS enabled for this node?"* | `gps_mode = 13` (`GpsMode` enum: `NOT_PRESENT`, `ENABLED`, `DISABLED`) | ✅ **Not shown** — PositionConfigScreen uses `gps_mode` exclusively. | ⚠️ **Read at load, written on save** — `setPositionValues()` reads `gpsMode` but also reads `deviceGpsEnabled` (the deprecated field) as a fallback: `if node?.positionConfig?.deviceGpsEnabled ?? false && gpsMode != 1 { self.gpsMode = 1 }`. On save, `pc.gpsEnabled = gpsMode == 1` actively writes the deprecated field alongside the new `pc.gpsMode`. |
-| `PositionConfig` | `gps_attempt_time = 6` — *"Deprecated in favor of using smart / regular broadcast intervals"* | Implicit via `position_broadcast_smart_enabled` / `position_broadcast_secs` | ✅ **Not shown** — no reference in PositionConfigScreen. | ✅ **Not shown** — no reference in PositionConfig.swift. |
-| `DisplayConfig` | `compass_north_top = 4` — *"If set, compass always points north"* | `compass_orientation` (enum: `DEGREES`, `NORTH_UP`, etc.) | ❌ **Still shown and writable** — DisplayConfigItemList renders a `SwitchPreference` bound to `formState.value.compass_north_top` and writes it back on save. The replacement `compass_orientation` field is not surfaced. | ❌ **Still shown and writable** — DisplayConfig.swift renders `Toggle(isOn: $compassNorthTop)`, reads `node?.displayConfig?.compassNorthTop` on load, and writes `dc.compassNorthTop = compassNorthTop` on save. The replacement `compass_orientation` field is not surfaced. |
-| `DisplayConfig` | `gps_format = 2` — *"Deprecated in 2.7.4: Unused. How GPS coordinates are formatted on the OLED."* | — (removed entirely, no replacement) | ✅ **Not shown** — no reference in DisplayConfigItemList. | ⚠️ **State variable exists but not rendered** — `@State var gpsFormat = 0` is declared and loaded from `node?.displayConfig?.gpsFormat`, but there is no UI element that reads or writes it. Dead code; field is never written on save. |
+| Proto message | Deprecated field | Deprecated since | Stable | Successor field | Android | Apple |
+|--------------|-----------------|-----------------|--------|----------------|---------|-------|
+| `PositionConfig` | `gps_enabled = 4` | `gps_mode` added v2.2.21 (2024-02-01); `[deprecated=true]` annotated **v2.7.4** | v2.7.15 | `gps_mode = 13` (`GpsMode` enum: `NOT_PRESENT / ENABLED / DISABLED`) | ✅ **Not shown** — PositionConfigScreen uses `gps_mode` exclusively. | ⚠️ **Written on every save** — reads `deviceGpsEnabled` as a fallback on load (legacy bridge), and saves `pc.gpsEnabled = gpsMode == 1` alongside `pc.gpsMode` on every write. Sends the deprecated field to all firmware versions regardless. |
+| `PositionConfig` | `gps_attempt_time = 6` | **v2.2.18** (2024-01-11 pre); stable v2.2.19 (2024-01-21) | v2.2.19 | Implicit via `position_broadcast_smart_enabled` / intervals | ✅ **Not shown** | ✅ **Not shown** |
+| `DisplayConfig` | `compass_north_top = 4` | `compass_orientation` added v2.3.13 (2024-06-18); `[deprecated=true]` annotated **v2.7.4** | v2.7.15 | `compass_orientation` enum (`DEGREES / NORTH_UP / HEADING_UP`) | ❌ **Still shown and writable** — `DisplayConfigItemList` renders a `SwitchPreference` for `compass_north_top` and writes it back. `compass_orientation` is not surfaced on either firmware range. | ❌ **Still shown and writable** — `Toggle(isOn: $compassNorthTop)` is rendered; `dc.compassNorthTop` is written on save. `compass_orientation` is not surfaced. |
+| `DisplayConfig` | `gps_format = 2` | **v2.7.4** (2025-08-09 pre) | v2.7.15 | Removed — unused | ✅ **Not shown** | ⚠️ **Dead state variable** — `@State var gpsFormat = 0` is declared and loaded but never rendered or written on save. |
 
 ---
 
 ### 5.4 Deprecated Fields — Removed from Active Use
 
-These fields have been deprecated without a direct named successor and are no longer relevant to firmware.
-
-| Proto message | Deprecated field | Android | Apple |
-|--------------|-----------------|---------|-------|
-| `CannedMessageConfig` | `enabled = 9` — *"Enable/disable CannedMessageModule"* (replaced by the module always being active when configured) | ❌ **Still shown and writable** — `CannedMessageConfigItemList` renders a `SwitchPreference` for `formState.value.enabled` and writes it back. Also has a max_size comment bug: `// allow_input_source max_size:16` on the wrong field (see §5.5). | ❌ **Still shown and writable** — CannedMessagesConfig.swift renders an `enabled` toggle and writes `cmc.enabled = enabled` on save. |
-| `CannedMessageConfig` | `allow_input_source = 10` — *"Input event origin, e.g. 'rotEnc1', 'upDownEnc1', '_any'"* | ❌ **Still shown and writable** — `CannedMessageConfigItemList` renders an `EditTextPreference` for `allow_input_source` with `maxSize = 63`. This is also a validation bug: the `.options` file specifies `max_size:16` (15 chars max) but Android enforces 63 bytes, which is a silent over-limit. | ❌ **Still shown and writable** — CannedMessagesConfig.swift writes `cmc.allowInputSource = "rotEnc1"`, `"upDown1"`, or `"_any"` via hard-coded option buttons. These are functional but writing a deprecated field. |
-| `User` | `macaddr = 4` — *"Deprecated in 2.1.x. Radio MAC address, added by ESP32 when broadcasting"* | ✅ **Not written** — no reference in settings UIs. Internal proto field only. | ✅ **Not written** — no reference in settings UIs. |
-| `MeshPacket` | `delayed = 13` | ✅ **Not referenced** in settings UIs. | ✅ **Not referenced** in settings UIs. |
+| Proto message | Deprecated field | Deprecated since | Stable | Android | Apple |
+|--------------|-----------------|-----------------|--------|---------|-------|
+| `CannedMessageConfig` | `enabled = 9` | **v2.7.4** (2025-08-09 pre) | v2.7.15 | ❌ **Still shown and writable** | ❌ **Still shown and writable** — toggle writes `cmc.enabled` on save |
+| `CannedMessageConfig` | `allow_input_source = 10` | **v2.7.4** (2025-08-09 pre) | v2.7.15 | ❌ **Still shown and writable** — also has a max_size bug (enforces 63 bytes; proto `max_size:16` → 15 chars) | ❌ **Still shown and writable** — hard-codes `"rotEnc1"`, `"upDown1"`, `"_any"` on save |
+| `User` | `macaddr = 4` | Deprecated in 2.1.x | — | ✅ Not in settings UIs | ✅ Not in settings UIs |
+| `MeshPacket` | `delayed = 13` | Deprecated in 2.1.x | — | ✅ Not in settings UIs | ✅ Not in settings UIs |
 
 ---
 
-### 5.5 Additional Finding: `allow_input_source` max_size mismatch
+### 5.5 Additional Finding: `allow_input_source` max_size mismatch (Android)
 
-While auditing deprecated field handling, a secondary validation bug was identified in Android's `CannedMessageConfigItemList`:
+Android's `CannedMessageConfigItemList` enforces `maxSize = 63` for `allow_input_source`, but the proto `.options` annotation is `max_size:16` (max 15 chars). The comment on the adjacent line even says `// allow_input_source max_size:16` but the constraint value is wrong. Since the field is also deprecated, the correct fix is removal rather than a size correction.
 
+---
+
+### 5.6 Firmware Version Gating Recommendations
+
+Both apps have built-in infrastructure for version-aware behaviour:
+
+**Android** — `DeviceVersion` (in `core/model`) converts version strings to a comparable integer (`2.7.12` → `20712`). Comparisons use `>=`:
 ```kotlin
-EditTextPreference(
-    title = stringResource(Res.string.allow_input_source),
-    value = formState.value.allow_input_source,
-    maxSize = 63, // allow_input_source max_size:16  ← comment references the wrong field
-    ...
-)
+// Pattern already used in the codebase:
+if (deviceVersion >= DeviceVersion("2.3.15")) {
+    // hide deprecated field / show replacement
+}
 ```
 
-The `.options` annotation is `*CannedMessageConfig.allow_input_source max_size:16` (max 15 chars). Android enforces 63 bytes — 4× the firmware limit. Since this field is also deprecated, the recommended fix is removal of the UI element rather than a size correction.
+**Apple** — `AccessoryManager.checkIsVersionSupported(forVersion:)` returns `true` when the connected firmware is ≥ the given version (uses `String.compare(..., options: .numeric)`):
+```swift
+// Pattern already used in the codebase (e.g. supportsTAKv2, heartbeat gating):
+if accessoryManager.checkIsVersionSupported(forVersion: "2.3.15") {
+    // hide deprecated field / show replacement
+}
+```
+
+The firmware version is available as `DeviceMetadata.firmware_version` (proto field 1), which both apps already read and store on connection.
+
+#### Per-field gating table
+
+| Field / Value | Hide/migrate when firmware ≥ | Backward behaviour for older firmware |
+|---------------|------------------------------|---------------------------------------|
+| `ROUTER_CLIENT` role | **v2.3.15** | Show as selectable option (both apps currently do this — ✅ Android already correct; ✅ Apple migrates) |
+| `REPEATER` role | **v2.7.11** | Show as selectable option; **Apple needs migration** from role 4 → show a "Role deprecated" warning or fall back to CLIENT |
+| `LONG_SLOW` preset | **v2.7.17** | Show as selectable option for firmware < 2.7.17; **Apple should add to `userSelectable` exclusion list** gated on `checkIsVersionSupported("2.7.17")` |
+| `VERY_LONG_SLOW` preset | **v2.5.0** | Show as selectable option for firmware < 2.5.0 (edge case — very old firmware only) |
+| `DeviceConfig.serial_enabled` | **v2.4.3** | Show legacy toggle for firmware < 2.4.3; ✅ both apps already handle this (neither shows the field) |
+| `DeviceConfig.is_managed` | **v2.4.3** | Same — ✅ both apps correct |
+| `PositionConfig.gps_enabled` write-back | **v2.7.4** | Write `pc.gpsEnabled` only when firmware < 2.7.4 as a backward-compat bridge; remove unconditional write otherwise. **Apple action required.** |
+| `PositionConfig.gps_attempt_time` | **v2.2.19** | Show for firmware < 2.2.19 — ✅ both apps already hide it |
+| `DisplayConfig.compass_north_top` | **v2.3.13** | Show old toggle only for firmware < 2.3.13; show `compass_orientation` picker for ≥ 2.3.13. **Both apps need updating.** |
+| `DisplayConfig.gps_format` | **v2.7.4** | Apple: remove dead `gpsFormat` state variable entirely |
+| `CannedMessageConfig.enabled` | **v2.7.4** | Show toggle for firmware < 2.7.4; hide for ≥ 2.7.4. **Both apps need updating.** |
+| `CannedMessageConfig.allow_input_source` | **v2.7.4** | Show text field for firmware < 2.7.4; hide for ≥ 2.7.4. **Both apps need updating.** |
+
+#### Suggested implementation pattern (Apple — `CannedMessagesConfig.swift`)
+```swift
+// Only show deprecated enable toggle for firmware that still honours it
+if !accessoryManager.checkIsVersionSupported(forVersion: "2.7.4") {
+    Toggle("Enable Canned Messages", isOn: $enabled)
+}
+
+// Use compass_orientation picker for modern firmware; legacy bool for old firmware
+if accessoryManager.checkIsVersionSupported(forVersion: "2.3.13") {
+    Picker("Compass Orientation", selection: $compassOrientation) { ... }
+} else {
+    Toggle("Compass North Top", isOn: $compassNorthTop)
+}
+```
+
+#### Suggested implementation pattern (Android — `CannedMessageConfigItemList.kt`)
+```kotlin
+val deviceVersion = state.deviceVersion // DeviceVersion from radioConfigState
+
+// Only show deprecated fields for firmware that still uses them
+if (deviceVersion < DeviceVersion("2.7.4")) {
+    SwitchPreference(title = "Enable", checked = formState.value.enabled, ...)
+    EditTextPreference(title = "Input Source", value = formState.value.allow_input_source, ...)
+}
+
+// Show compass_orientation for modern firmware, legacy bool for old
+if (deviceVersion >= DeviceVersion("2.3.13")) {
+    DropDownPreference(title = "Compass Orientation", selectedItem = formState.value.compass_orientation, ...)
+} else {
+    SwitchPreference(title = "Compass North Top", checked = formState.value.compass_north_top, ...)
+}
+```
 
 ---
 
-### 5.6 Recommendations
+### 5.7 Summary Matrix
 
-| Priority | Action | Rationale |
-|----------|--------|-----------|
-| **High** | **Apple: remove `LONG_SLOW` from `ModemPresets.userSelectable`** | Deprecated in v2.7. Android already filters it. New users can inadvertently select a deprecated, unsupported preset. Existing devices using LONG_SLOW should continue to display the label but not be offered the option. |
-| **High** | **Both: replace `compass_north_top` with `compass_orientation`** | The deprecated toggle is still the only compass UI on both platforms. The replacement `compass_orientation` enum field is fully defined in the proto and present in firmware but not exposed in either app. |
-| **High** | **Apple: add a migration for `REPEATER` role** | Unlike `ROUTER_CLIENT` (which Apple migrates to `CLIENT_MUTE`), a device configured as `REPEATER` will have `DeviceRoles(rawValue: 4)` return `nil`, producing undefined UI behaviour. Should migrate to an appropriate replacement (e.g. `CLIENT` or display an explicit deprecation warning). |
-| **Medium** | **Both: stop writing `CannedMessageConfig.enabled` and `allow_input_source`** | Both fields are deprecated. `enabled` has no firmware effect in current versions. `allow_input_source` should be removed from UI; input routing is now handled by the hardware-specific toggles (`rotary1_enabled`, `updown1_enabled`). |
-| **Medium** | **Apple: stop writing `PositionConfig.gps_enabled` on save** | The deprecated `gps_enabled` field is redundantly written alongside `gps_mode`. Firmware ignores the deprecated field in current versions; writing it risks confusing older firmware and creates unnecessary proto churn. Remove `pc.gpsEnabled = gpsMode == 1`. |
-| **Low** | **Apple: remove `gpsFormat` dead-code state variable** | `@State var gpsFormat` is loaded but never rendered or written. Remove it to reduce noise. |
-| **Low** | **Android: fix the misplaced `allow_input_source` comment** | `maxSize = 63, // allow_input_source max_size:16` — the comment is on the line, not the field, and the size is wrong. Moot if the field is removed (recommended above), but should be fixed if it is retained. |
+| # | Item | Deprecated since (stable) | Android | Apple | Priority |
+|---|------|--------------------------|---------|-------|----------|
+| A | `ROUTER_CLIENT` role | v2.3.15 | ✅ Filtered | ✅ Migrated | — Done |
+| B | `REPEATER` role | v2.7.15 | ✅ Filtered | ❌ No migration; nil rawValue | High |
+| C | `LONG_SLOW` preset | *(no stable yet)* | ✅ Filtered | ❌ Still selectable | High |
+| D | `compass_north_top` → `compass_orientation` | v2.7.15 | ❌ Still writable | ❌ Still writable | High |
+| E | `CannedMessageConfig.enabled` | v2.7.15 | ❌ Still writable | ❌ Still writable | Medium |
+| F | `CannedMessageConfig.allow_input_source` | v2.7.15 | ❌ Still writable (+size bug) | ❌ Still writable | Medium |
+| G | `PositionConfig.gps_enabled` write-back | v2.7.15 | ✅ Not written | ❌ Written unconditionally | Medium |
+| H | `VERY_LONG_SLOW` preset | v2.7.15 (comment: v2.5) | ✅ Filtered | ✅ Absent | — Done |
+| I | `gps_format` dead code | v2.7.15 | ✅ Not shown | ⚠️ Dead state var | Low |
+| J | `DeviceConfig.serial_enabled` / `is_managed` | v2.7.15 | ✅ Correctly hidden | ✅ Correctly hidden | — Done |
+| K | `gps_attempt_time` | v2.2.19 | ✅ Not shown | ✅ Not shown | — Done |

--- a/standards/audits/settings-validation-matrix.md
+++ b/standards/audits/settings-validation-matrix.md
@@ -245,3 +245,93 @@ These module config screens are present in Android but have no equivalent in the
 | App Settings | Enable Administration | Apple-only toggle |
 | Network Config | `udp_enabled` | Apple-only toggle |
 | TAK Module | `enabled` | Apple shows an explicit enable toggle |
+---
+
+## 5. Deprecated Field Handling
+
+This section audits all fields and enum values marked `[deprecated = true]` in the Meshtastic protobufs and compares how Android and Apple handle them in their UIs. Fields may be deprecated because: they were moved to a different message, replaced by a successor field, or removed from active firmware support.
+
+### Methodology
+
+Proto files were inspected for the `[deprecated = true]` annotation. The `.options` files were also cross-referenced. For each deprecated item the UI source code of both apps was read to determine whether the item is: **hidden** (not shown to users), **shown but read-only / informational**, **still writable** (the deprecated field is actively surfaced and written), or **actively migrated** (the app converts the old value to the replacement on load).
+
+---
+
+### 5.1 Deprecated Enum Values
+
+These proto enum values are annotated `[deprecated = true]` and should not be offered in new configurations.
+
+| Enum | Value | Deprecated since | Reason | Android | Apple |
+|------|-------|-----------------|--------|---------|-------|
+| `DeviceConfig.Role` | `ROUTER_CLIENT = 3` | v2.3.15 | Improper usage impacting public meshes; use ROUTER or CLIENT instead | ✅ **Filtered out** — `DropDownPreference` uses JVM reflection (`isDeprecatedEnumEntry()`) to remove all deprecated enum constants from the picker at runtime. `@Suppress("DEPRECATION")` allows the existing value to be read and displayed if a device already has this role. | ✅ **Absent from enum + actively migrated** — `DeviceRoles` Swift enum has no `routerClient` case. On view load, `setDeviceValues()` silently rewrites role 3 → 1 (`CLIENT_MUTE`): `if node?.deviceConfig?.role ?? 0 == 3 { node?.deviceConfig?.role = 1 }` |
+| `DeviceConfig.Role` | `REPEATER = 4` | v2.7.11 | Creates "holes" in the mesh rebroadcast chain | ✅ **Filtered out** via `isDeprecatedEnumEntry()` reflection. Still readable/displayable if device has it. Included in `infrastructureRoles` list so it triggers the router role confirmation dialog. | ⚠️ **Absent from enum but no migration** — `DeviceRoles` has no `repeater` case. A device configured as REPEATER will have `deviceRole = 4`, which won't match any `DeviceRoles` case; `DeviceRoles(rawValue: 4)` returns `nil`. No explicit migration to a replacement role. |
+| `LoRaConfig.ModemPreset` | `LONG_SLOW = 1` | v2.7 | Unpopular slow preset | ✅ **Filtered out** via `isDeprecatedEnumEntry()` reflection. | ❌ **Still offered** — `ModemPresets` Swift enum includes `case longSlow = 1` and it is not excluded from `userSelectable`. Users can still select LONG_SLOW from the modem preset picker. |
+| `LoRaConfig.ModemPreset` | `VERY_LONG_SLOW = 2` | v2.5 | Works only with TCXO and unusably slow | ✅ **Filtered out** via `isDeprecatedEnumEntry()` reflection. | ✅ **Absent from enum** — `ModemPresets` has no `veryLongSlow` case. A device with this preset will have an unrecognised raw value in the picker. No migration logic. |
+
+---
+
+### 5.2 Deprecated Fields — Moved to Another Message
+
+These fields were physically relocated to a different proto message. They remain in the original message for backward compatibility but should no longer be written.
+
+| Proto message | Field | Moved to | Android | Apple |
+|--------------|-------|----------|---------|-------|
+| `DeviceConfig` | `serial_enabled = 2` | `SecurityConfig.serial_enabled` | ✅ **Not shown** — DeviceConfigScreen has no reference to `serial_enabled`. The current value lives in SecurityConfig. | ✅ **Not shown** — DeviceConfig.swift has no reference. |
+| `DeviceConfig` | `is_managed = 9` | `SecurityConfig.is_managed` | ✅ **Not shown** in DeviceConfigScreen. Correctly surfaced only via SecurityConfigScreen. | ✅ **Not shown** in DeviceConfig.swift. Correctly surfaced only via SecurityConfig.swift. |
+
+---
+
+### 5.3 Deprecated Fields — Replaced by a Successor Field
+
+These fields were superseded by a newer field in the same message. The deprecated field should not be written and ideally should not be shown.
+
+| Proto message | Deprecated field | Successor field | Android | Apple |
+|--------------|-----------------|----------------|---------|-------|
+| `PositionConfig` | `gps_enabled = 4` — *"Is GPS enabled for this node?"* | `gps_mode = 13` (`GpsMode` enum: `NOT_PRESENT`, `ENABLED`, `DISABLED`) | ✅ **Not shown** — PositionConfigScreen uses `gps_mode` exclusively. | ⚠️ **Read at load, written on save** — `setPositionValues()` reads `gpsMode` but also reads `deviceGpsEnabled` (the deprecated field) as a fallback: `if node?.positionConfig?.deviceGpsEnabled ?? false && gpsMode != 1 { self.gpsMode = 1 }`. On save, `pc.gpsEnabled = gpsMode == 1` actively writes the deprecated field alongside the new `pc.gpsMode`. |
+| `PositionConfig` | `gps_attempt_time = 6` — *"Deprecated in favor of using smart / regular broadcast intervals"* | Implicit via `position_broadcast_smart_enabled` / `position_broadcast_secs` | ✅ **Not shown** — no reference in PositionConfigScreen. | ✅ **Not shown** — no reference in PositionConfig.swift. |
+| `DisplayConfig` | `compass_north_top = 4` — *"If set, compass always points north"* | `compass_orientation` (enum: `DEGREES`, `NORTH_UP`, etc.) | ❌ **Still shown and writable** — DisplayConfigItemList renders a `SwitchPreference` bound to `formState.value.compass_north_top` and writes it back on save. The replacement `compass_orientation` field is not surfaced. | ❌ **Still shown and writable** — DisplayConfig.swift renders `Toggle(isOn: $compassNorthTop)`, reads `node?.displayConfig?.compassNorthTop` on load, and writes `dc.compassNorthTop = compassNorthTop` on save. The replacement `compass_orientation` field is not surfaced. |
+| `DisplayConfig` | `gps_format = 2` — *"Deprecated in 2.7.4: Unused. How GPS coordinates are formatted on the OLED."* | — (removed entirely, no replacement) | ✅ **Not shown** — no reference in DisplayConfigItemList. | ⚠️ **State variable exists but not rendered** — `@State var gpsFormat = 0` is declared and loaded from `node?.displayConfig?.gpsFormat`, but there is no UI element that reads or writes it. Dead code; field is never written on save. |
+
+---
+
+### 5.4 Deprecated Fields — Removed from Active Use
+
+These fields have been deprecated without a direct named successor and are no longer relevant to firmware.
+
+| Proto message | Deprecated field | Android | Apple |
+|--------------|-----------------|---------|-------|
+| `CannedMessageConfig` | `enabled = 9` — *"Enable/disable CannedMessageModule"* (replaced by the module always being active when configured) | ❌ **Still shown and writable** — `CannedMessageConfigItemList` renders a `SwitchPreference` for `formState.value.enabled` and writes it back. Also has a max_size comment bug: `// allow_input_source max_size:16` on the wrong field (see §5.5). | ❌ **Still shown and writable** — CannedMessagesConfig.swift renders an `enabled` toggle and writes `cmc.enabled = enabled` on save. |
+| `CannedMessageConfig` | `allow_input_source = 10` — *"Input event origin, e.g. 'rotEnc1', 'upDownEnc1', '_any'"* | ❌ **Still shown and writable** — `CannedMessageConfigItemList` renders an `EditTextPreference` for `allow_input_source` with `maxSize = 63`. This is also a validation bug: the `.options` file specifies `max_size:16` (15 chars max) but Android enforces 63 bytes, which is a silent over-limit. | ❌ **Still shown and writable** — CannedMessagesConfig.swift writes `cmc.allowInputSource = "rotEnc1"`, `"upDown1"`, or `"_any"` via hard-coded option buttons. These are functional but writing a deprecated field. |
+| `User` | `macaddr = 4` — *"Deprecated in 2.1.x. Radio MAC address, added by ESP32 when broadcasting"* | ✅ **Not written** — no reference in settings UIs. Internal proto field only. | ✅ **Not written** — no reference in settings UIs. |
+| `MeshPacket` | `delayed = 13` | ✅ **Not referenced** in settings UIs. | ✅ **Not referenced** in settings UIs. |
+
+---
+
+### 5.5 Additional Finding: `allow_input_source` max_size mismatch
+
+While auditing deprecated field handling, a secondary validation bug was identified in Android's `CannedMessageConfigItemList`:
+
+```kotlin
+EditTextPreference(
+    title = stringResource(Res.string.allow_input_source),
+    value = formState.value.allow_input_source,
+    maxSize = 63, // allow_input_source max_size:16  ← comment references the wrong field
+    ...
+)
+```
+
+The `.options` annotation is `*CannedMessageConfig.allow_input_source max_size:16` (max 15 chars). Android enforces 63 bytes — 4× the firmware limit. Since this field is also deprecated, the recommended fix is removal of the UI element rather than a size correction.
+
+---
+
+### 5.6 Recommendations
+
+| Priority | Action | Rationale |
+|----------|--------|-----------|
+| **High** | **Apple: remove `LONG_SLOW` from `ModemPresets.userSelectable`** | Deprecated in v2.7. Android already filters it. New users can inadvertently select a deprecated, unsupported preset. Existing devices using LONG_SLOW should continue to display the label but not be offered the option. |
+| **High** | **Both: replace `compass_north_top` with `compass_orientation`** | The deprecated toggle is still the only compass UI on both platforms. The replacement `compass_orientation` enum field is fully defined in the proto and present in firmware but not exposed in either app. |
+| **High** | **Apple: add a migration for `REPEATER` role** | Unlike `ROUTER_CLIENT` (which Apple migrates to `CLIENT_MUTE`), a device configured as `REPEATER` will have `DeviceRoles(rawValue: 4)` return `nil`, producing undefined UI behaviour. Should migrate to an appropriate replacement (e.g. `CLIENT` or display an explicit deprecation warning). |
+| **Medium** | **Both: stop writing `CannedMessageConfig.enabled` and `allow_input_source`** | Both fields are deprecated. `enabled` has no firmware effect in current versions. `allow_input_source` should be removed from UI; input routing is now handled by the hardware-specific toggles (`rotary1_enabled`, `updown1_enabled`). |
+| **Medium** | **Apple: stop writing `PositionConfig.gps_enabled` on save** | The deprecated `gps_enabled` field is redundantly written alongside `gps_mode`. Firmware ignores the deprecated field in current versions; writing it risks confusing older firmware and creates unnecessary proto churn. Remove `pc.gpsEnabled = gpsMode == 1`. |
+| **Low** | **Apple: remove `gpsFormat` dead-code state variable** | `@State var gpsFormat` is loaded but never rendered or written. Remove it to reduce noise. |
+| **Low** | **Android: fix the misplaced `allow_input_source` comment** | `maxSize = 63, // allow_input_source max_size:16` — the comment is on the line, not the field, and the size is wrong. Moot if the field is removed (recommended above), but should be fixed if it is retained. |


### PR DESCRIPTION
Adds **Section 5: Deprecated Field Handling** to the settings validation matrix.

All fields and enum values marked `[deprecated = true]` in the protobufs were identified by inspecting `config.proto`, `module_config.proto`, and `mesh.proto`, then cross-referencing with the `.options` files. The actual UI source code of both apps was read to determine how each is handled.

### 14 deprecated items audited across 4 categories

**5.1 — Deprecated enum values (4 items)**
- `DeviceConfig.Role.ROUTER_CLIENT` (v2.3.15), `REPEATER` (v2.7.11)
- `LoRaConfig.ModemPreset.LONG_SLOW` (v2.7), `VERY_LONG_SLOW` (v2.5)

**5.2 — Fields moved to another message (2 items)**
- `DeviceConfig.serial_enabled` → `SecurityConfig`
- `DeviceConfig.is_managed` → `SecurityConfig`

**5.3 — Fields replaced by a successor (4 items)**
- `PositionConfig.gps_enabled` → `gps_mode`
- `PositionConfig.gps_attempt_time` → implicit via smart broadcast
- `DisplayConfig.compass_north_top` → `compass_orientation`
- `DisplayConfig.gps_format` → removed

**5.4 — Fields removed from active use (4 items)**
- `CannedMessageConfig.enabled`, `allow_input_source`
- `User.macaddr`, `MeshPacket.delayed`

### Key findings

| Finding | Severity |
|---------|----------|
| Apple still offers `LONG_SLOW` in the modem preset picker | High |
| Apple has no migration for `REPEATER` role (nil rawValue) | High |
| Both apps still show/write deprecated `compass_north_top` instead of `compass_orientation` | High |
| Both apps still write deprecated `CannedMessageConfig.enabled` | Medium |
| Apple writes deprecated `gps_enabled` on every position config save | Medium |
| Android's `allow_input_source` enforces 63 bytes; proto `max_size:16` (new finding) | Medium |
| Apple has a dead-code `@State var gpsFormat` that is loaded but never used | Low |

### Section 5.5 — Bonus finding
Android's `CannedMessageConfigItemList` has `maxSize = 63` on the `allow_input_source` field with the comment `// allow_input_source max_size:16` — the comment is correct but the size is 4× over-limit. This is in addition to the field being deprecated.
